### PR TITLE
Fix Hero subtitle markup and add SocialProof & ValueProps sections

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,18 +1,14 @@
 import Hero from '@/components/Hero';
-import FeatureList from './_PageSections/FeatureList';
-import Feature from './_PageSections/Feature';
-import LogoCloud from './_PageSections/LogoCloud';
+import { SocialProof } from '@/components/SocialProof';
+import { ValueProps } from '@/components/ValueProps';
 import CTA from './_PageSections/CTA';
 
 export default function Landing() {
   return (
     <div>
       <Hero />
-      <LogoCloud />
-      <FeatureList />
-      <Feature />
-      <Feature isFlipped={true} />
-      <Feature />
+      <SocialProof />
+      <ValueProps />
       <CTA />
     </div>
   );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -7,18 +7,11 @@ import { Icons } from '@/components/Icons';
 import { cn } from '@/lib/utils/helpers';
 import { useI18n } from '@/components/I18nProvider';
 
-const features = [
-  'Plug & play with your existing camera network',
-  'Instant alerts and comprehensive reports',
-  'Fully scalable and ERP/WMS-ready'
-];
-
 
 const demoLink = '/demo';
 
 export default function Hero() {
   const { t } = useI18n();
-  const features = t.hero.bullets;
   return (
     <section className="py-16 lg:py-24">
       <div className="max-w-7xl mx-auto grid grid-cols-1 items-center gap-12 px-6 lg:grid-cols-2 lg:px-8">
@@ -29,7 +22,7 @@ export default function Hero() {
           <p className="mt-6 text-lg text-muted-foreground">
             {t.hero.subtitle}
             Computer Vision for Real-Time Logistics Control
-          </h1>
+          </p>
           <p className="mt-6 text-lg text-muted-foreground">
             Detect, track, and audit everything that enters, leaves, or moves inside your logistics center or factory — using your existing cameras.
           </p>
@@ -53,7 +46,7 @@ export default function Hero() {
             </Link>
           </div>
           <ul role="list" className="mt-8 space-y-3">
-            {features.map((feature) => (
+            {t.hero.bullets.map((feature) => (
               <li key={feature} className="flex gap-3">
                 <Icons.Check className="h-5 w-5 flex-none text-primary" aria-hidden="true" />
                 <span className="text-sm sm:text-base">{feature}</span>

--- a/src/components/SocialProof.tsx
+++ b/src/components/SocialProof.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import * as React from 'react';
+import { useI18n } from '@/components/I18nProvider';
+
+export const SocialProof: React.FC = () => {
+  const { t } = useI18n();
+  return (
+    <section aria-labelledby="social-proof" className="py-8 sm:py-10">
+      <div className="max-w-7xl mx-auto px-6 lg:px-8">
+        <h2 id="social-proof" className="text-center text-sm text-muted-foreground">
+          {t.social.trusted}
+        </h2>
+        <div
+          aria-label={t.social.logosAlt}
+          className="mt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-6 items-center justify-items-center opacity-80"
+        >
+          {/* Replace placeholders with real logos when available */}
+          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
+          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
+          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
+          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
+          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
+        </div>
+      </div>
+    </section>
+  );
+};
+

--- a/src/components/ValueProps.tsx
+++ b/src/components/ValueProps.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import * as React from 'react';
+import { useI18n } from '@/components/I18nProvider';
+
+// Minimal icon placeholders (inline SVG) to avoid deps
+const icons = {
+  Integration: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" {...props}>
+      <path d="M8 12h8" stroke="currentColor" strokeWidth="1.6" />
+      <path d="M3 12h2M19 12h2" stroke="currentColor" strokeWidth="1.6" />
+      <rect x="6" y="6" width="4" height="12" rx="1" stroke="currentColor" fill="none" />
+      <rect x="14" y="6" width="4" height="12" rx="1" stroke="currentColor" fill="none" />
+    </svg>
+  ),
+  'Real-time': (props: React.SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" {...props}>
+      <circle cx="12" cy="12" r="9" stroke="currentColor" fill="none" />
+      <path d="M12 7v6l4 2" stroke="currentColor" />
+    </svg>
+  ),
+  Reports: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" {...props}>
+      <rect x="4" y="3" width="16" height="18" rx="2" stroke="currentColor" fill="none" />
+      <path d="M8 8h8M8 12h8M8 16h6" stroke="currentColor" />
+    </svg>
+  ),
+  Scalable: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" {...props}>
+      <path d="M4 17h6v3H4zM10 13h6v7h-6zM16 9h6v11h-6z" fill="none" stroke="currentColor" />
+    </svg>
+  ),
+};
+
+export const ValueProps: React.FC = () => {
+  const { t } = useI18n();
+  const items = t.valueProps.items;
+
+  // Map icon by English iconLabel; Spanish variant maps to the same keys
+  const iconFor = (label: string) => {
+    if (label.toLowerCase().includes('integr')) return icons.Integration;
+    if (label.toLowerCase().includes('real')) return icons['Real-time'];
+    if (label.toLowerCase().includes('report')) return icons.Reports;
+    return icons.Scalable;
+    // default
+  };
+
+  return (
+    <section aria-labelledby="value-props" className="py-12 sm:py-16">
+      <div className="max-w-7xl mx-auto px-6 lg:px-8">
+        <h2 id="value-props" className="text-2xl sm:text-3xl font-semibold tracking-tight">
+          {t.valueProps.title}
+        </h2>
+        <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          {items.map((it, idx) => {
+            const Icon = iconFor(it.iconLabel);
+            return (
+              <article key={idx} className="rounded-2xl border p-6 shadow-sm bg-card">
+                <div className="flex items-center gap-3">
+                  <Icon className="text-foreground/80" />
+                  <span className="sr-only">{it.iconLabel}</span>
+                </div>
+                <h3 className="mt-4 text-lg font-medium">{it.title}</h3>
+                <p className="mt-2 text-sm text-muted-foreground">{it.text}</p>
+              </article>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+};
+

--- a/src/lib/i18n-dict.ts
+++ b/src/lib/i18n-dict.ts
@@ -18,6 +18,18 @@ export const i18nDict: Record<Locale, {
     ctaSecondary: string;
     bullets: string[];
   };
+  social: {
+    trusted: string;
+    logosAlt: string;
+  };
+  valueProps: {
+    title: string;
+    items: {
+      iconLabel: string;
+      title: string;
+      text: string;
+    }[];
+  };
 }> = {
   en: {
     navbar: {
@@ -40,6 +52,35 @@ export const i18nDict: Record<Locale, {
         'Fully scalable and ERP/WMS-ready',
       ],
     },
+    social: {
+      trusted: 'Trusted by leaders in logistics, manufacturing, and retail',
+      logosAlt: 'Partner and customer logos',
+    },
+    valueProps: {
+      title: 'Why ANGai',
+      items: [
+        {
+          iconLabel: 'Integration',
+          title: 'Easy integration',
+          text: 'Connect to your existing camera network in minutes — no extra hardware needed.',
+        },
+        {
+          iconLabel: 'Real-time',
+          title: 'Real-time detection',
+          text: 'Get instant alerts for vehicles, pallets, and goods movement.',
+        },
+        {
+          iconLabel: 'Reports',
+          title: 'Actionable reports',
+          text: 'Access detailed audits, KPIs, and compliance-ready documentation.',
+        },
+        {
+          iconLabel: 'Scalable',
+          title: 'Scalable SaaS',
+          text: 'Grow from one site to hundreds with a fully managed cloud platform.',
+        },
+      ],
+    },
   },
   es: {
     navbar: {
@@ -60,6 +101,35 @@ export const i18nDict: Record<Locale, {
         'Plug & play con tu red de cámaras existente',
         'Alertas instantáneas e informes completos',
         'Totalmente escalable y compatible con ERP/WMS',
+      ],
+    },
+    social: {
+      trusted: 'Confiado por líderes en logística, manufactura y retail',
+      logosAlt: 'Logotipos de socios y clientes',
+    },
+    valueProps: {
+      title: 'Por qué ANGai',
+      items: [
+        {
+          iconLabel: 'Integración',
+          title: 'Integración sencilla',
+          text: 'Conecta con tu red de cámaras existente en minutos — sin hardware adicional.',
+        },
+        {
+          iconLabel: 'Tiempo real',
+          title: 'Detección en tiempo real',
+          text: 'Recibe alertas instantáneas de vehículos, pallets y movimientos de mercancías.',
+        },
+        {
+          iconLabel: 'Reportes',
+          title: 'Reportes accionables',
+          text: 'Accede a auditorías detalladas, KPIs y documentación lista para cumplimiento.',
+        },
+        {
+          iconLabel: 'Escalable',
+          title: 'SaaS escalable',
+          text: 'Escala de un sitio a cientos con una plataforma en la nube totalmente gestionada.',
+        },
       ],
     },
   },


### PR DESCRIPTION
## Summary
- extend i18n dictionary with social proof and value props entries for EN/ES
- add SocialProof and ValueProps components and render them after Hero
- streamline landing page to show Hero, SocialProof, ValueProps, and CTA

## Testing
- `npm run lint`
- `npm test` *(fails: cross-env not found)*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689b52265ca88326a637b87036a9398c