### PR TITLE
Enhance marketing sections and integrate Inter font

### DIFF
--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,6 +1,7 @@
 import Hero from '@/components/Hero';
 import { SocialProof } from '@/components/SocialProof';
 import { ValueProps } from '@/components/ValueProps';
+import { Promise } from '@/components/Promise';
 import CTA from './_PageSections/CTA';
 
 export default function Landing() {
@@ -9,6 +10,7 @@ export default function Landing() {
       <Hero />
       <SocialProof />
       <ValueProps />
+      <Promise />
       <CTA />
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,11 +5,14 @@ import 'react-toastify/dist/ReactToastify.min.css';
 import NextTopLoader from 'nextjs-toploader';
 import config from '@/lib/config/site';
 import { I18nProvider } from '@/components/I18nProvider';
+import { Inter } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-sans' });
 
 const RootLayout = ({ children }) => {
   return (
-    <html suppressHydrationWarning lang="en"> 
-      <body>
+    <html suppressHydrationWarning lang="en" className={`${inter.variable} font-sans`}>
+      <body className="antialiased">
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -22,19 +22,18 @@ export default function Hero() {
             {t.hero.sub}
           </p>
 
-          {/* CTAs: stacked on mobile, inline on desktop */}
-          <div className="mt-6 flex flex-col space-y-3 sm:flex-row sm:space-y-0 sm:space-x-4">
+          {/* CTAs: stacked on mobile, aligned inline on desktop */}
+          <div className="mt-6 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4">
             <Link
               href={demoLink}
-              className="w-full sm:w-auto bg-primary text-white font-medium rounded-lg px-5 py-3 text-center hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+              className="inline-flex items-center justify-center w-full sm:w-auto rounded-lg px-5 py-3 bg-primary text-white font-medium hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
               aria-label={t.hero.cta1}
             >
               {t.hero.cta1}
             </Link>
-
             <Link
               href="#use-cases"
-              className="w-full sm:w-auto text-base font-medium underline underline-offset-4 hover:no-underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 text-center"
+              className="inline-flex items-center justify-center w-full sm:w-auto rounded-lg px-5 py-3 border bg-transparent font-medium hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
               aria-label={t.hero.cta2}
             >
               {t.hero.cta2}

--- a/src/components/Promise.tsx
+++ b/src/components/Promise.tsx
@@ -2,33 +2,35 @@
 import Link from 'next/link';
 import { useI18n } from '@/components/I18nProvider';
 
-export default function CTA() {
+export const Promise: React.FC = () => {
   const { t } = useI18n();
   return (
-    <section id="cta" className="py-14 sm:py-16">
+    <section className="py-14 sm:py-16">
       <div className="max-w-4xl mx-auto px-6 lg:px-8 text-center">
-        <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight">
-          {/* Simple headline; adjust later if needed */}
-          Ready to see ANGai in action?
+        <p className="text-sm font-medium text-muted-foreground uppercase tracking-wide">
+          {t.promise.kicker}
+        </p>
+        <h2 className="mt-2 text-3xl sm:text-4xl font-bold tracking-tight">
+          {t.promise.title}
         </h2>
-        <p className="mt-3 text-base sm:text-lg text-muted-foreground">
-          Start with our pricing or talk to us to tailor a plan for your operations.
+        <p className="mt-4 text-base sm:text-lg text-muted-foreground">
+          {t.promise.body}
         </p>
         <div className="mt-6 flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 justify-center">
           <Link
             href="#pricing"
             className="inline-flex items-center justify-center rounded-lg px-5 py-3 bg-primary text-white font-medium hover:bg-primary/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
           >
-            {t.promise.ctaPrimary /* 'See Pricing' / 'Ver Precios' */}
+            {t.promise.ctaPrimary}
           </Link>
           <Link
             href="#contact"
             className="inline-flex items-center justify-center rounded-lg px-5 py-3 border font-medium hover:bg-muted focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
           >
-            {t.promise.ctaSecondary /* 'Contact Us' / 'Contáctanos' */}
+            {t.promise.ctaSecondary}
           </Link>
         </div>
       </div>
     </section>
   );
-}
+};

--- a/src/components/SocialProof.tsx
+++ b/src/components/SocialProof.tsx
@@ -13,14 +13,16 @@ export const SocialProof: React.FC = () => {
         </h2>
         <div
           aria-label={t.social.logosAlt}
-          className="mt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-6 items-center justify-items-center opacity-80"
+          className="mt-6 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-6 gap-6 items-center justify-items-center opacity-80"
         >
-          {/* Replace placeholders with real logos when available */}
-          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
-          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
-          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
-          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
-          <div className="h-8 w-24 bg-neutral-300 dark:bg-neutral-700 rounded-md" aria-hidden="true" />
+          {t.social.tech.slice(0, 6).map((name: string) => (
+            <div
+              key={name}
+              className="h-9 min-w-28 px-4 rounded-md border text-sm flex items-center justify-center text-muted-foreground"
+            >
+              {name}
+            </div>
+          ))}
         </div>
       </div>
     </section>

--- a/src/components/ValueProps.tsx
+++ b/src/components/ValueProps.tsx
@@ -30,6 +30,28 @@ const icons = {
       <path d="M4 17h6v3H4zM10 13h6v7h-6zM16 9h6v11h-6z" fill="none" stroke="currentColor" />
     </svg>
   ),
+  Edge: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" {...props}>
+      <circle cx="12" cy="12" r="3" stroke="currentColor" fill="none" />
+      <path d="M12 2v4M12 18v4M2 12h4M18 12h4" stroke="currentColor" />
+    </svg>
+  ),
+  Privacy: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" {...props}>
+      <path d="M12 3l8 4v5c0 5-3 9-8 10-5-1-8-5-8-10V7l8-4z" stroke="currentColor" fill="none" />
+    </svg>
+  ),
+  Integrations: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" {...props}>
+      <path d="M9 2v6M15 2v6M7 10h10v4a5 5 0 11-10 0v-4z" stroke="currentColor" fill="none" />
+    </svg>
+  ),
+  FinOps: (props: React.SVGProps<SVGSVGElement>) => (
+    <svg viewBox="0 0 24 24" width="24" height="24" aria-hidden="true" {...props}>
+      <circle cx="12" cy="12" r="8" stroke="currentColor" fill="none" />
+      <path d="M12 8v8M9 12h6" stroke="currentColor" />
+    </svg>
+  ),
 };
 
 export const ValueProps: React.FC = () => {
@@ -38,11 +60,16 @@ export const ValueProps: React.FC = () => {
 
   // Map icon by English iconLabel; Spanish variant maps to the same keys
   const iconFor = (label: string) => {
-    if (label.toLowerCase().includes('integr')) return icons.Integration;
-    if (label.toLowerCase().includes('real')) return icons['Real-time'];
-    if (label.toLowerCase().includes('report')) return icons.Reports;
+    const lower = label.toLowerCase();
+    if (lower.includes('integrations') || lower.includes('integraciones')) return icons.Integrations;
+    if (lower.includes('integration') || lower.includes('integración')) return icons.Integration;
+    if (lower.includes('real')) return icons['Real-time'];
+    if (lower.includes('report') || lower.includes('reporte')) return icons.Reports;
+    if (lower.includes('edge')) return icons.Edge;
+    if (lower.includes('priv')) return icons.Privacy;
+    if (lower.includes('finops') || lower.includes('cost')) return icons.FinOps;
+    if (lower.includes('scal') || lower.includes('escal')) return icons.Scalable;
     return icons.Scalable;
-    // default
   };
 
   return (

--- a/src/lib/config/marketing.ts
+++ b/src/lib/config/marketing.ts
@@ -68,15 +68,6 @@ const config = {
       apple: '/apple-touch-icon.png'
     },
     manifest: `${siteConfig.url}/site.webmanifest`
-  },
-  copy: {
-    cta: {
-      heading: 'Boost your productivity.',
-      heading_line2: 'Start using our app today.',
-      subheading: `Incididunt sint fugiat pariatur cupidatat consectetur sit cillum anim id veniam aliqua proident excepteur commodo do ea.`,
-      link1_text: 'See Pricing',
-      link2_text: '  Learn More '
-    }
   }
 };
 

--- a/src/lib/i18n-dict.ts
+++ b/src/lib/i18n-dict.ts
@@ -22,6 +22,7 @@ export const i18nDict: Record<Locale, {
   social: {
     trusted: string;
     logosAlt: string;
+    tech: string[];
   };
   valueProps: {
     title: string;
@@ -30,6 +31,13 @@ export const i18nDict: Record<Locale, {
       title: string;
       text: string;
     }[];
+  };
+  promise: {
+    kicker: string;
+    title: string;
+    body: string;
+    ctaPrimary: string;
+    ctaSecondary: string;
   };
 }> = {
   en: {
@@ -54,8 +62,9 @@ export const i18nDict: Record<Locale, {
       ],
     },
     social: {
-      trusted: 'Trusted by leaders in logistics, manufacturing, and retail',
-      logosAlt: 'Partner and customer logos',
+      trusted: 'Built with a modern, proven stack',
+      logosAlt: 'Technology ecosystem logos',
+      tech: ['AWS', 'Kubernetes', 'Terraform', 'OpenCV', 'Python', 'ONVIF'],
     },
     valueProps: {
       title: 'Why ANGai',
@@ -80,7 +89,34 @@ export const i18nDict: Record<Locale, {
           title: 'Scalable SaaS',
           text: 'Grow from one site to hundreds with a fully managed cloud platform.',
         },
+        {
+          iconLabel: 'Edge',
+          title: 'Edge + Cloud',
+          text: 'Run models at the edge or in the cloud to balance latency and cost.',
+        },
+        {
+          iconLabel: 'Privacy',
+          title: 'Security & privacy',
+          text: 'Role-based access, on-prem options, and anonymization for sensitive footage.',
+        },
+        {
+          iconLabel: 'Integrations',
+          title: 'ERP/WMS integrations',
+          text: 'Connect with your ERP/WMS via REST/Webhooks for automated workflows.',
+        },
+        {
+          iconLabel: 'FinOps',
+          title: 'Cost control',
+          text: 'Usage-based pricing, monitoring and optimizations to keep costs predictable.',
+        },
       ],
+    },
+    promise: {
+      kicker: 'Deploy in days, not months',
+      title: 'From cameras to real-time logistics control — fast',
+      body: 'Connect your existing camera network and start detecting vehicles, pallets, and goods movement in days. No custom hardware, no fragile pipelines — just a managed, scalable platform that fits your ERP/WMS.',
+      ctaPrimary: 'See Pricing',
+      ctaSecondary: 'Contact Us',
     },
   },
   es: {
@@ -105,8 +141,9 @@ export const i18nDict: Record<Locale, {
       ],
     },
     social: {
-      trusted: 'Confiado por líderes en logística, manufactura y retail',
-      logosAlt: 'Logotipos de socios y clientes',
+      trusted: 'Construido con un stack moderno y probado',
+      logosAlt: 'Logotipos del ecosistema tecnológico',
+      tech: ['AWS', 'Kubernetes', 'Terraform', 'OpenCV', 'Python', 'ONVIF'],
     },
     valueProps: {
       title: 'Por qué ANGai',
@@ -131,36 +168,34 @@ export const i18nDict: Record<Locale, {
           title: 'SaaS escalable',
           text: 'Escala de un sitio a cientos con una plataforma en la nube totalmente gestionada.',
         },
-      ],
-    },
-    social: {
-      trusted: 'Confiado por líderes en logística, manufactura y retail',
-      logosAlt: 'Logotipos de socios y clientes',
-    },
-    valueProps: {
-      title: 'Por qué ANGai',
-      items: [
         {
-          iconLabel: 'Integración',
-          title: 'Integración sencilla',
-          text: 'Conecta con tu red de cámaras existente en minutos — sin hardware adicional.',
+          iconLabel: 'Edge',
+          title: 'Edge + Cloud',
+          text: 'Ejecuta modelos en el edge o en la nube para equilibrar latencia y costo.',
         },
         {
-          iconLabel: 'Tiempo real',
-          title: 'Detección en tiempo real',
-          text: 'Recibe alertas instantáneas de vehículos, pallets y movimientos de mercancías.',
+          iconLabel: 'Privacidad',
+          title: 'Seguridad y privacidad',
+          text: 'Acceso basado en roles, opciones on-prem y anonimización para material sensible.',
         },
         {
-          iconLabel: 'Reportes',
-          title: 'Reportes accionables',
-          text: 'Accede a auditorías detalladas, KPIs y documentación lista para cumplimiento.',
+          iconLabel: 'Integraciones',
+          title: 'Integraciones ERP/WMS',
+          text: 'Conecta con tu ERP/WMS vía REST/Webhooks para flujos automatizados.',
         },
         {
-          iconLabel: 'Escalable',
-          title: 'SaaS escalable',
-          text: 'Escala de un sitio a cientos con una plataforma en la nube totalmente gestionada.',
+          iconLabel: 'FinOps',
+          title: 'Control de costos',
+          text: 'Precios basados en uso, monitoreo y optimizaciones para mantener costos predecibles.',
         },
       ],
+    },
+    promise: {
+      kicker: 'Despliega en días, no meses',
+      title: 'De cámaras a control logístico en tiempo real — rápido',
+      body: 'Conecta tu red de cámaras existente y empieza a detectar vehículos, pallets y movimientos en días. Sin hardware a medida, sin pipelines frágiles — plataforma gestionada y escalable que encaja con tu ERP/WMS.',
+      ctaPrimary: 'Ver Precios',
+      ctaSecondary: 'Contáctanos',
     },
   },
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -46,7 +46,7 @@ const config: Config = {
         sm: 'calc(var(--radius) - 4px)'
       },
       fontFamily: {
-        sans: ['var(--font-inter)']
+        sans: ['var(--font-sans)', 'system-ui', 'Arial', 'sans-serif']
       },
       animation: {
         fadeIn: 'fadeIn 700ms ease-in-out'


### PR DESCRIPTION
## Summary
- localize promise CTAs, tech stack, and expanded value props in i18n dictionary
- add dual-CTA Promise section and tech stack SocialProof with 8-card ValueProps
- integrate Inter via next/font and remove obsolete CTA section
- add marketing CTA section linked to pricing and contact anchors

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `NODE_ENV=test npx playwright test` *(fails: Prisma query error during global teardown)*

------
https://chatgpt.com/codex/tasks/task_e_689b7ed0bcbc8326952fd51fc467f494